### PR TITLE
XDG_CONFIG_HOME

### DIFF
--- a/doc/ictree.1
+++ b/doc/ictree.1
@@ -226,10 +226,10 @@ it's impossible to use more than one character in a mapping.
 .
 .SH FILES
 .TP
-.B $XDG_CONFIG_PATH/ictree/config
+.B $XDG_CONFIG_HOME/ictree/config
 Configuration file.
 If
-.B $XDG_CONFIG_PATH
+.B $XDG_CONFIG_HOME
 is not defined,
 .B $HOME/.config
 is used instead.

--- a/src/config.c
+++ b/src/config.c
@@ -170,7 +170,7 @@ int read_config(Command **cmd)
 
     static char config_path[FILENAME_MAX];
 
-    char *xdg_conf_p = getenv("XDG_CONFIG_PATH");
+    char *xdg_conf_p = getenv("XDG_CONFIG_HOME");
     if (xdg_conf_p != NULL) {
         strncpy(config_path, xdg_conf_p, FILENAME_MAX - 1);
     } else {


### PR DESCRIPTION
Hi, thanks for ictree. I noticed it uses `$XDG_CONFIG_PATH` but it's `XDG_CONFIG_HOME` in the [freedesktop.org spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).