### PR TITLE
Use left key to goto parent or fold

### DIFF
--- a/src/ictree.c
+++ b/src/ictree.c
@@ -131,6 +131,7 @@ static int setup_signals();
 static int unfold(void);
 static int update_screen(void);
 static UpdScrSignal goto_parent(void);
+static UpdScrSignal goto_parent_or_fold(void);
 static UpdScrSignal handle_key(struct tb_event ev);
 static UpdScrSignal handle_mouse_click(int x, int y);
 static UpdScrSignal handle_mouse(struct tb_event ev);
@@ -322,6 +323,18 @@ static void toggle_fold(void)
         assert(fold() == 1);
         break;
     }
+}
+
+static UpdScrSignal goto_parent_or_fold(void)
+{
+    switch (get_path_from_link(paths.links[cursor_pos])->state) {
+    case PathStateFolded:
+        return goto_parent();
+    case PathStateUnfolded:
+        assert(fold() == 1);
+        return UpdScrSignalYes;
+    }
+    return UpdScrSignalNo;
 }
 
 static void quit(void)
@@ -653,7 +666,7 @@ static UpdScrSignal handle_key(struct tb_event ev)
     case TB_KEY_ARROW_UP:
         CONTROL_ACTION(cursor_move(-1));
     case TB_KEY_ARROW_LEFT:
-        CONTROL_ACTION(fold());
+        CONTROL_ACTION(goto_parent_or_fold());
     case TB_KEY_ARROW_RIGHT:
         CONTROL_ACTION(unfold());
     case TB_KEY_ENTER:


### PR DESCRIPTION
Fixes #13

Pressing `Left` on an item would:

- If it has children, and it is unfolded, then fold this item.
- If it has children, and it is folded, then go to it's parent.
- If it is a leaf (as in it doesn't have any children - so it can't be folded / unfolded) then go to it's parent.