### PR TITLE
Sorted lines as command line argument

### DIFF
--- a/doc/ictree.1
+++ b/doc/ictree.1
@@ -31,7 +31,11 @@ or any other program output that is a list of paths.
 Fold directories by default.
 .
 .TP
-\fB\-\-separator=\fP\fIC\fP, \fB\-s\fP\fIC\fP
+.BR \-\-sort ", " \-s
+Display sorted entries.
+.
+.TP
+\fB\-\-delimiter=\fP\fIC\fP, \fB\-d\fP\fIC\fP
 Set directory separator to
 .IR C .
 .RB \(oq / \(cq

--- a/gen/help-msg.h
+++ b/gen/help-msg.h
@@ -4,7 +4,9 @@
 "Options:" "\n" \
 "       --fold, -f" "\n" \
 "              Fold directories by default." "\n" \
-"       --separator=<C>, -s <C>" "\n" \
+"       --sort, -s" "\n" \
+"              Display sorted entries." "\n" \
+"       --delimiter=<C>, -d <C>" "\n" \
 "              Set directory separator to C.  / is the default value." "\n" \
 "       --help, -h" "\n" \
 "              Print a help message and exit." "\n" \

--- a/include/args.h
+++ b/include/args.h
@@ -20,6 +20,7 @@
 #define ARGS_H
 
 #include "paths.h"
+#include "lines.h"
 
 enum ArgAction {
     ArgActionDefault,
@@ -31,6 +32,7 @@ enum ArgAction {
 typedef struct Options {
     char *filename;
     PathState init_paths_state;
+    LinesState init_lines_state;
     char separator;
 } Options;
 

--- a/include/lines.h
+++ b/include/lines.h
@@ -24,6 +24,11 @@
 
 #define LINE_DELIM '\n'
 
+typedef enum LinesState {
+    LinesStateUnsorted,
+    LinesStateSorted
+} LinesState;
+
 typedef struct Lines {
     char **lines;
     size_t lines_l;

--- a/src/args.c
+++ b/src/args.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "args.h"
+#include "lines.h"
 #include "error.h"
 #include "version.h"
 
@@ -32,13 +33,14 @@
 
 static struct option long_opts[] = {
     { "fold",       no_argument,        NULL,  'f' },
-    { "separator",  required_argument,  NULL,  's' },
+    { "sort",       no_argument,        NULL,  's' },
+    { "delimiter",  required_argument,  NULL,  'd' },
     { "version",    no_argument,        NULL,  'v' },
     { "help",       no_argument,        NULL,  'h' },
     { 0,            0,                  NULL,  0   },
 };
 
-#define SHORT_OPTIONS "fs:vh"
+#define SHORT_OPTIONS "fsd:vh"
 
 enum ArgAction process_args(Options *options, int argc, char **argv)
 {
@@ -57,6 +59,9 @@ enum ArgAction process_args(Options *options, int argc, char **argv)
             options->init_paths_state = PathStateFolded;
             break;
         case 's':
+            options->init_lines_state = LinesStateSorted;
+            break;
+        case 'd':
             if (strlen(optarg) != 1) {
                 set_error("directory separator must a single character");
                 return ArgActionErrorReport;

--- a/src/ictree.c
+++ b/src/ictree.c
@@ -1116,7 +1116,10 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    sort_lines(lines);
+    if (options.init_lines_state == LinesStateSorted) {
+        sort_lines(lines);
+    }
+
     total_paths_l = get_paths(&paths, lines.lines, lines.lines_l, options.separator, options.init_paths_state);
 
     if (setup_signals() != 0) {

--- a/src/ictree.c
+++ b/src/ictree.c
@@ -229,6 +229,7 @@ static void init_options(void)
 {
     options.filename = NULL;
     options.init_paths_state = PathStateUnfolded;
+    options.init_lines_state = LinesStateUnsorted;
     options.separator = '/';
 }
 

--- a/src/paths.c
+++ b/src/paths.c
@@ -185,10 +185,13 @@ void unfold_nested_path(UnfoldedPaths *unfolded_paths, Path *path, size_t *pos)
     cvector_free(queue);
 }
 
-static char *get_full_path(PathLink *links, size_t links_l, char *line)
+static char *get_full_path(PathLink *links, size_t links_l, char *line, char separator)
 {
     unsigned long i;
     unsigned long str_l;
+    char separator_str[] = "/";
+
+    separator_str[0] = separator;
 
     str_l = 0;
     for (i = 0; i < links_l; i++) {
@@ -197,7 +200,7 @@ static char *get_full_path(PathLink *links, size_t links_l, char *line)
     }
 
     if (strlen(line) == 0)
-        line = "/";
+        line = separator_str;
 
     str_l += strlen(line);
 
@@ -205,7 +208,7 @@ static char *get_full_path(PathLink *links, size_t links_l, char *line)
 
     for (i = 0; i < links_l; i++) {
         strncat(str, get_path_from_link(links[i])->line, str_l);
-        strncat(str, "/", str_l);
+        strncat(str, separator_str, str_l);
     }
 
     strncat(str, line, str_l);
@@ -322,7 +325,7 @@ size_t get_paths(UnfoldedPaths *unfolded_paths, char **lines, size_t lines_l, ch
             cvector_push_back(unfolded_paths->links, pl);
         }
 
-        p.full_path = get_full_path(stack, cvector_size(stack), p.line);
+        p.full_path = get_full_path(stack, cvector_size(stack), p.line, separator);
 
         cvector_push_back(stack, pl);
         cvector_push_back(paths, p);


### PR DESCRIPTION
Added line sorting as an option.
Moved '-s' (separator) option to '-d' (delimiter) and assigned '-s' to sort (sort).
This assignment seems more natural to me and consistent with other commands like 'ls' and 'cut'.
